### PR TITLE
Add payment status redirect

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
+import PaymentStatus from "./pages/PaymentStatus";
 import NotFound from "./pages/NotFound";
 
 const queryClient = new QueryClient();
@@ -16,6 +17,7 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/payment-status" element={<PaymentStatus />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/PaymentModal.tsx
+++ b/src/components/PaymentModal.tsx
@@ -7,6 +7,7 @@ import { useAuth } from '@/hooks/useAuth';
 import { supabase } from '@/integrations/supabase/client';
 import { toast } from 'sonner';
 import { Sparkles, Zap, Star } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
 
 interface PaymentModalProps {
   isOpen: boolean;
@@ -17,6 +18,7 @@ interface PaymentModalProps {
 
 const PaymentModal = ({ isOpen, onClose, onPaymentSuccess, isDark = true }: PaymentModalProps) => {
   const { user } = useAuth();
+  const navigate = useNavigate();
   const [isProcessing, setIsProcessing] = useState(false);
 
   const paymentPackages = [
@@ -89,9 +91,9 @@ const PaymentModal = ({ isOpen, onClose, onPaymentSuccess, isDark = true }: Paym
 
       if (error) throw error;
 
-      // Redirect to Paymob payment page
+      // Navigate to payment status page with Paymob URL
       if (data?.paymentUrl) {
-        window.open(data.paymentUrl, '_blank');
+        navigate(`/payment-status?transactionId=${transaction.id}&paymentUrl=${encodeURIComponent(data.paymentUrl)}`);
         toast.success('Redirecting to payment...');
         onClose();
       } else {

--- a/src/pages/PaymentStatus.tsx
+++ b/src/pages/PaymentStatus.tsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { useSearchParams, useNavigate } from 'react-router-dom';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from 'sonner';
+
+const PaymentStatus = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const transactionId = searchParams.get('transactionId');
+  const paymentUrl = searchParams.get('paymentUrl');
+  const [status, setStatus] = useState<string | null>(null);
+
+  // Redirect to Paymob if paymentUrl is present (initial navigation)
+  useEffect(() => {
+    if (paymentUrl && transactionId) {
+      const returnUrl = `${window.location.origin}/payment-status?transactionId=${transactionId}`;
+      const url = decodeURIComponent(paymentUrl) + `&return_url=${encodeURIComponent(returnUrl)}`;
+      window.location.replace(url);
+    }
+  }, [paymentUrl, transactionId]);
+
+  // Poll for transaction status when returning from Paymob
+  useEffect(() => {
+    if (!paymentUrl && transactionId) {
+      const interval = setInterval(async () => {
+        const { data, error } = await supabase
+          .from('payment_transactions')
+          .select('status')
+          .eq('id', transactionId)
+          .single();
+
+        if (error) {
+          toast.error('Failed to check payment status');
+          clearInterval(interval);
+          return;
+        }
+
+        if (data?.status) {
+          setStatus(data.status);
+          if (data.status === 'completed' || data.status === 'failed') {
+            clearInterval(interval);
+            setTimeout(() => navigate('/'), 3000);
+          }
+        }
+      }, 3000);
+
+      return () => clearInterval(interval);
+    }
+  }, [paymentUrl, transactionId, navigate]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      {status === 'completed' && <p className="text-green-600 text-xl">Payment successful! Redirecting...</p>}
+      {status === 'failed' && <p className="text-red-600 text-xl">Payment failed. Redirecting...</p>}
+      {!status && <p className="text-lg">Checking payment status...</p>}
+    </div>
+  );
+};
+
+export default PaymentStatus;


### PR DESCRIPTION
## Summary
- route `/payment-status` handles Paymob returns
- navigate to this route from `PaymentModal`

## Testing
- `npm run build`
- `npm run lint` *(fails: 31 problems)*

------
https://chatgpt.com/codex/tasks/task_b_68555aecabd8832cbe4c8d3f932d9170