### PR TITLE
Add mixed interpretation style

### DIFF
--- a/src/components/HelpSupport.tsx
+++ b/src/components/HelpSupport.tsx
@@ -29,7 +29,8 @@ const HelpSupport = ({ isDark = true }: HelpSupportProps) => {
     },
     {
       question: "What are the different interpretation styles?",
-      answer: "We offer three interpretation styles: Islamic (based on traditional Islamic dream interpretation), Spiritual (symbolic and intuitive insights), and Psychological (based on modern psychology and dream analysis)."
+      answer:
+        "We offer four interpretation styles: Islamic (based on traditional Islamic dream interpretation), Spiritual (symbolic and intuitive insights), Psychological (focusing on the mind and subconscious), and Mixed (a combination of all styles)."
     },
     {
       question: "How accurate are the dream interpretations?",

--- a/src/components/OnboardingFlow.tsx
+++ b/src/components/OnboardingFlow.tsx
@@ -177,8 +177,8 @@ const OnboardingFlow = ({ userName, onComplete, isDark = true }: OnboardingFlowP
             </div>
             
             <div className={`flex items-center space-x-2 p-3 rounded-lg border ${
-              formData.preferredStyle === 'spiritual' 
-                ? 'border-purple-500 bg-purple-500/10' 
+              formData.preferredStyle === 'spiritual'
+                ? 'border-purple-500 bg-purple-500/10'
                 : isDark ? 'border-slate-700' : 'border-slate-300'
             }`}>
               <RadioGroupItem value="spiritual" id="spiritual" />
@@ -186,6 +186,20 @@ const OnboardingFlow = ({ userName, onComplete, isDark = true }: OnboardingFlowP
                 <div className="font-medium">Spiritual</div>
                 <div className={`text-sm ${isDark ? 'text-slate-500' : 'text-slate-600'}`}>
                   Symbolic and intuitive meanings from universal wisdom
+                </div>
+              </Label>
+            </div>
+
+            <div className={`flex items-center space-x-2 p-3 rounded-lg border ${
+              formData.preferredStyle === 'mixed'
+                ? 'border-yellow-500 bg-yellow-500/10'
+                : isDark ? 'border-slate-700' : 'border-slate-300'
+            }`}>
+              <RadioGroupItem value="mixed" id="mixed" />
+              <Label htmlFor="mixed" className={`flex-1 cursor-pointer ${isDark ? 'text-slate-300' : 'text-slate-700'}`}>
+                <div className="font-medium">All styles</div>
+                <div className={`text-sm ${isDark ? 'text-slate-500' : 'text-slate-600'}`}>
+                  Combination of all interpretation styles
                 </div>
               </Label>
             </div>


### PR DESCRIPTION
## Summary
- allow selecting all interpretation styles in onboarding
- document all four styles in FAQ

## Testing
- `npm test`
- `npm run lint` *(fails: Unexpected any, prefer-const, etc.)*


------
https://chatgpt.com/codex/tasks/task_b_6856f99026ac832cb539100e17a36acb