### PR TITLE
Enable Arabic option for interpretations

### DIFF
--- a/src/hooks/useDreams.tsx
+++ b/src/hooks/useDreams.tsx
@@ -162,7 +162,7 @@ export const useDreams = () => {
   });
 
   const interpretDreamMutation = useMutation({
-    mutationFn: async (dreamText: string) => {
+    mutationFn: async ({ dreamText, language }: { dreamText: string; language?: string }) => {
       // The `canInterpret` check is now done in the UI component before calling this.
 
       console.log('Starting dream interpretation...');
@@ -191,9 +191,10 @@ export const useDreams = () => {
       };
 
       const { data, error } = await supabase.functions.invoke('interpret-dream', {
-        body: { 
+        body: {
           dreamText,
-          userContext 
+          userContext,
+          language
         }
       });
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -93,7 +93,7 @@ const Index = () => {
     setCurrentDream(dreamText);
     try {
       console.log('Starting dream interpretation process...');
-      await interpretDream(dreamText);
+      await interpretDream({ dreamText, language: preferences.language });
       console.log('Dream interpretation completed, now incrementing usage...');
       
       // Add a small delay to ensure the interpretation completed successfully
@@ -109,7 +109,7 @@ const Index = () => {
   const handlePaymentSuccess = () => {
     setShowPaymentModal(false);
     if (currentDream) {
-      interpretDream(currentDream);
+      interpretDream({ dreamText: currentDream, language: preferences.language });
     }
   };
 

--- a/supabase/functions/interpret-dream/index.ts
+++ b/supabase/functions/interpret-dream/index.ts
@@ -14,7 +14,7 @@ serve(async (req) => {
   try {
     console.log('Starting dream interpretation request...')
     
-    const { dreamText, userContext } = await req.json()
+    const { dreamText, userContext, language } = await req.json()
     console.log('Received dream text:', dreamText?.substring(0, 100) + '...')
     console.log('User context:', userContext)
     
@@ -37,8 +37,9 @@ serve(async (req) => {
       )
     }
 
-    // Detect if the dream text contains Arabic characters
-    const isArabic = /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(dreamText)
+    // Detect if Arabic is requested or if the dream text contains Arabic characters
+    const isArabic = language === 'ar' || /[\u0600-\u06FF\u0750-\u077F\u08A0-\u08FF\uFB50-\uFDFF\uFE70-\uFEFF]/.test(dreamText)
+    console.log('Requested language:', language)
     console.log('Detected Arabic text:', isArabic)
 
     // Build user context string for personalization


### PR DESCRIPTION
## Summary
- allow the interpret function to receive preferred language
- send user language from the UI when interpreting dreams
- respect preferred language in Supabase function

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_685704fb05a4832c91da9098395ef45c