### PR TITLE
Add basic Arabic language support

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import PaymentStatus from "./pages/PaymentStatus";
 import NotFound from "./pages/NotFound";
+import { LanguageProvider } from "@/context/LanguageContext";
 
 const queryClient = new QueryClient();
 
@@ -14,14 +15,16 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          <Route path="/payment-status" element={<PaymentStatus />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <LanguageProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            <Route path="/payment-status" element={<PaymentStatus />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </LanguageProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/components/DreamInput.tsx
+++ b/src/components/DreamInput.tsx
@@ -5,6 +5,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Card, CardHeader, CardContent, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Progress } from '@/components/ui/progress';
+import { useLanguage } from '@/context/LanguageContext';
 
 interface DreamInputProps {
   onSubmit: (dream: string) => void;
@@ -15,6 +16,7 @@ interface DreamInputProps {
 const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) => {
   const [dreamText, setDreamText] = useState('');
   const [progress, setProgress] = useState(0);
+  const { t, language } = useLanguage();
 
   React.useEffect(() => {
     if (isAnalyzing) {
@@ -56,10 +58,10 @@ const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) =
             </div>
           </div>
           <CardTitle className="hologram-text text-xl">
-            Share Your Dream
+            {t('shareYourDream')}
           </CardTitle>
           <p className={`text-sm ${isDark ? 'text-slate-400' : 'text-slate-600'}`}>
-            Describe your dream in detail for the most accurate interpretation
+            {t('describeYourDream')}
           </p>
         </CardHeader>
         
@@ -67,7 +69,7 @@ const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) =
           <form onSubmit={handleSubmit} className="space-y-6">
             <div>
               <Label htmlFor="dream" className={`font-medium ${isDark ? 'text-slate-300' : 'text-slate-700'}`}>
-                Dream Description
+                {t('dreamDescription')}
               </Label>
               <Textarea
                 id="dream"
@@ -87,7 +89,7 @@ const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) =
               <div className="space-y-3">
                 <div className="flex items-center justify-between">
                   <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-slate-600'}`}>
-                    Analyzing your dream...
+                    {t('analyzing')}
                   </span>
                   <span className={`text-sm ${isDark ? 'text-slate-400' : 'text-slate-600'}`}>
                     {Math.round(progress)}%
@@ -95,7 +97,7 @@ const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) =
                 </div>
                 <Progress value={progress} className="h-2" />
                 <div className={`text-center text-xs ${isDark ? 'text-slate-500' : 'text-slate-400'}`}>
-                  Estimated wait time: {estimatedWaitTime}
+                  {t('estimatedWaitTime')}: {estimatedWaitTime}
                 </div>
               </div>
             )}
@@ -110,12 +112,12 @@ const DreamInput = ({ onSubmit, isAnalyzing, isDark = true }: DreamInputProps) =
               {isAnalyzing ? (
                 <div className="flex items-center space-x-2">
                   <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin"></div>
-                  <span>Interpreting your dream...</span>
+                  <span>{t('analyzing')}</span>
                 </div>
               ) : (
                 <div className="flex items-center space-x-2">
                   <div className="w-4 h-4 bg-white/20 rounded-full"></div>
-                  <span>Interpret My Dream</span>
+                  <span>{t('interpretDream')}</span>
                 </div>
               )}
             </Button>

--- a/src/components/settings/AppPreferencesSection.tsx
+++ b/src/components/settings/AppPreferencesSection.tsx
@@ -6,6 +6,7 @@ import { Switch } from '@/components/ui/switch';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Globe } from 'lucide-react';
 import { toast } from 'sonner';
+import { useLanguage } from '@/context/LanguageContext';
 
 interface AppPreferencesSectionProps {
   userPreferences: any;
@@ -15,11 +16,16 @@ interface AppPreferencesSectionProps {
 }
 
 const AppPreferencesSection = ({ userPreferences, isDark = true, onThemeToggle, onUpdatePreferences }: AppPreferencesSectionProps) => {
+  const { t, setLanguage } = useLanguage();
+
   const handleLanguageChange = (language: string) => {
     onUpdatePreferences({
       language: language
     });
-    toast.success(`Language changed to ${language === 'ar' ? 'Arabic' : 'English'}`);
+    setLanguage(language as 'en' | 'ar');
+    toast.success(
+      t('language') + ' ' + (language === 'ar' ? 'العربية' : 'English')
+    );
   };
 
   return (
@@ -33,7 +39,7 @@ const AppPreferencesSection = ({ userPreferences, isDark = true, onThemeToggle, 
         <div className="flex items-center justify-between">
           <div>
             <Label htmlFor="theme" className={`font-medium ${isDark ? 'text-slate-300' : 'text-slate-700'}`}>
-              Dark Mode
+              {t('darkMode')}
             </Label>
             <p className={`text-sm ${isDark ? 'text-slate-400' : 'text-slate-600'}`}>
               Use dark theme across the app
@@ -47,17 +53,17 @@ const AppPreferencesSection = ({ userPreferences, isDark = true, onThemeToggle, 
             <div className="flex items-center space-x-2">
               <Globe className={`h-4 w-4 ${isDark ? 'text-slate-400' : 'text-slate-600'}`} />
               <Label htmlFor="language" className={`font-medium ${isDark ? 'text-slate-300' : 'text-slate-700'}`}>
-                Language
+                {t('language')}
               </Label>
             </div>
             <p className={`text-sm ${isDark ? 'text-slate-400' : 'text-slate-600'}`}>
-              Choose your preferred language
+              {t('chooseLanguage')}
             </p>
           </div>
           <div className="w-32">
             <Select value={userPreferences?.language || 'en'} onValueChange={handleLanguageChange}>
               <SelectTrigger className={isDark ? 'bg-slate-900/50 border-slate-700 text-slate-200' : 'bg-white border-slate-300'}>
-                <SelectValue placeholder="Language" />
+                <SelectValue placeholder={t('language')} />
               </SelectTrigger>
               <SelectContent>
                 <SelectItem value="en">English</SelectItem>

--- a/src/context/LanguageContext.tsx
+++ b/src/context/LanguageContext.tsx
@@ -1,0 +1,54 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type Language = 'en' | 'ar';
+
+const translations: Record<Language, Record<string, string>> = {
+  en: {
+    shareYourDream: 'Share Your Dream',
+    describeYourDream: 'Describe your dream in detail for the most accurate interpretation',
+    dreamDescription: 'Dream Description',
+    analyzing: 'Analyzing your dream...',
+    interpretDream: 'Interpret My Dream',
+    darkMode: 'Dark Mode',
+    language: 'Language',
+    chooseLanguage: 'Choose your preferred language',
+    estimatedWaitTime: 'Estimated wait time'
+  },
+  ar: {
+    shareYourDream: 'شارك حلمك',
+    describeYourDream: 'وصف حلمك بالتفصيل للحصول على تفسير أدق',
+    dreamDescription: 'وصف الحلم',
+    analyzing: 'يتم تحليل حلمك...',
+    interpretDream: 'فسر حلمي',
+    darkMode: 'الوضع الداكن',
+    language: 'اللغة',
+    chooseLanguage: 'اختر لغتك المفضلة',
+    estimatedWaitTime: 'الوقت المتوقع'
+  }
+};
+
+interface LanguageContextValue {
+  language: Language;
+  setLanguage: (lang: Language) => void;
+  t: (key: string) => string;
+}
+
+const LanguageContext = createContext<LanguageContextValue | undefined>(undefined);
+
+export const LanguageProvider = ({ children, initialLanguage = 'en' }: { children: ReactNode; initialLanguage?: Language }) => {
+  const [language, setLanguage] = useState<Language>(initialLanguage);
+  const t = (key: string) => translations[language][key] || key;
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage, t }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+};
+
+export const useLanguage = () => {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within LanguageProvider');
+  }
+  return context;
+};

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -21,6 +21,7 @@ import { useUserPreferences } from '@/hooks/useUserPreferences';
 import { useUserUsage } from '@/hooks/useUserUsage';
 import { useUserProfile } from '@/hooks/useUserProfile';
 import { useReferralSystem } from '@/hooks/useReferralSystem';
+import { useLanguage } from '@/context/LanguageContext';
 
 type ScreenType = 'home' | 'interpretation' | 'history' | 'settings' | 'subscription' | 'help' | 'myplan';
 
@@ -32,6 +33,7 @@ const Index = () => {
   const { profile, updateProfile, needsOnboarding } = useUserProfile();
   // Initialize referral system to handle referral codes in the URL
   useReferralSystem();
+  const { setLanguage } = useLanguage();
   
   const [currentScreen, setCurrentScreen] = useState<ScreenType>('home');
   const [currentDream, setCurrentDream] = useState<string>('');
@@ -46,6 +48,13 @@ const Index = () => {
       setIsDark(preferences.theme === 'dark');
     }
   }, [preferences?.theme]);
+
+  // Sync language with preferences
+  useEffect(() => {
+    if (preferences?.language) {
+      setLanguage(preferences.language as 'en' | 'ar');
+    }
+  }, [preferences?.language, setLanguage]);
 
   // Apply theme to body
   useEffect(() => {


### PR DESCRIPTION
## Summary
- create a simple language context with English and Arabic strings
- wrap app with LanguageProvider
- sync language preference with provider in main page
- localise DreamInput and language selector text

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run build` *(fails: vite not found)*
- `npx tsc -p tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_b_685706d4751c832cb5b4f422038c59f3